### PR TITLE
Fix CompanyBooking controller schema references

### DIFF
--- a/lib/ain_com_booking_api/controllers/company/company_booking_controller.ex
+++ b/lib/ain_com_booking_api/controllers/company/company_booking_controller.ex
@@ -104,7 +104,7 @@ defmodule AinComBookingApi.Controllers.Company.CompanyBookingController do
 
   def update(conn, %{"id" => id} = params) do
     # optional: ensure the booking exists
-    case Repo.get(Booking, id) do
+    case Repo.get(CompanyBooking, id) do
       nil ->
         conn
         |> put_status(:not_found)
@@ -139,7 +139,7 @@ defmodule AinComBookingApi.Controllers.Company.CompanyBookingController do
   end
 
   def index(conn, _params) do
-    bookings = Repo.all(Booking)
+    bookings = Repo.all(CompanyBooking)
     json(conn, bookings)
   end
 


### PR DESCRIPTION
## Summary
- fix Ecto queryable errors by using CompanyBooking schema in CompanyBookingController

## Testing
- `mix format lib/ain_com_booking_api/controllers/company/company_booking_controller.ex` *(fails: {undef,[{elixir,start_cli,[],[]},...]})*
- `mix test` *(fails: {undef,[{elixir,start_cli,[],[]},...]})*

------
https://chatgpt.com/codex/tasks/task_e_6895a760a7f08330ae78a34158070bba