### PR TITLE
style: add tailwind spacing to auth liveviews

### DIFF
--- a/lib/ain_com_booking_web/live/user_confirmation_instructions_live.ex
+++ b/lib/ain_com_booking_web/live/user_confirmation_instructions_live.ex
@@ -6,7 +6,7 @@ defmodule AinComBookingWeb.UserConfirmationInstructionsLive do
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">
         No confirmation instructions received?
         <:subtitle>We'll send a new confirmation link to your inbox</:subtitle>
@@ -21,7 +21,7 @@ defmodule AinComBookingWeb.UserConfirmationInstructionsLive do
         </:actions>
       </.simple_form>
 
-      <p class="text-center mt-4">
+      <p class="text-center text-sm mt-4">
         <.link href={~p"/users/register"}>Register</.link>
         | <.link href={~p"/users/log_in"}>Log in</.link>
       </p>

--- a/lib/ain_com_booking_web/live/user_confirmation_live.ex
+++ b/lib/ain_com_booking_web/live/user_confirmation_live.ex
@@ -6,7 +6,7 @@ defmodule AinComBookingWeb.UserConfirmationLive do
 
   def render(%{live_action: :edit} = assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">Confirm Account</.header>
 
       <.simple_form for={@form} id="confirmation_form" phx-submit="confirm_account">
@@ -16,7 +16,7 @@ defmodule AinComBookingWeb.UserConfirmationLive do
         </:actions>
       </.simple_form>
 
-      <p class="text-center mt-4">
+      <p class="text-center text-sm mt-4">
         <.link href={~p"/users/register"}>Register</.link>
         | <.link href={~p"/users/log_in"}>Log in</.link>
       </p>

--- a/lib/ain_com_booking_web/live/user_forgot_password_live.ex
+++ b/lib/ain_com_booking_web/live/user_forgot_password_live.ex
@@ -6,7 +6,7 @@ defmodule AinComBookingWeb.UserForgotPasswordLive do
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">
         Forgot your password?
         <:subtitle>We'll send a password reset link to your inbox</:subtitle>

--- a/lib/ain_com_booking_web/live/user_login_live.ex
+++ b/lib/ain_com_booking_web/live/user_login_live.ex
@@ -4,7 +4,7 @@ defmodule AinComBookingWeb.UserLoginLive do
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">
         Log in to account
         <:subtitle>

--- a/lib/ain_com_booking_web/live/user_registration_live.ex
+++ b/lib/ain_com_booking_web/live/user_registration_live.ex
@@ -7,7 +7,7 @@ defmodule AinComBookingWeb.UserRegistrationLive do
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">
         Register for an account
         <:subtitle>

--- a/lib/ain_com_booking_web/live/user_reset_password_live.ex
+++ b/lib/ain_com_booking_web/live/user_reset_password_live.ex
@@ -6,7 +6,7 @@ defmodule AinComBookingWeb.UserResetPasswordLive do
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-sm">
+    <div class="mx-auto max-w-sm p-4">
       <.header class="text-center">Reset Password</.header>
 
       <.simple_form

--- a/lib/ain_com_booking_web/live/user_settings_live.ex
+++ b/lib/ain_com_booking_web/live/user_settings_live.ex
@@ -11,7 +11,7 @@ defmodule AinComBookingWeb.UserSettingsLive do
       <:subtitle>Manage your account email address and password settings</:subtitle>
     </.header>
 
-    <div class="space-y-12 divide-y">
+    <div class="mx-auto max-w-2xl space-y-12 divide-y p-4">
       <div>
         <.simple_form
           for={@email_form}


### PR DESCRIPTION
## Summary
- add consistent padding to user auth pages
- standardize link text size in confirmation flows
- wrap settings forms in centered container

## Testing
- `mix format lib/ain_com_booking_web/live/user_login_live.ex lib/ain_com_booking_web/live/user_registration_live.ex lib/ain_com_booking_web/live/user_forgot_password_live.ex lib/ain_com_booking_web/live/user_confirmation_instructions_live.ex lib/ain_com_booking_web/live/user_reset_password_live.ex lib/ain_com_booking_web/live/user_confirmation_live.ex lib/ain_com_booking_web/live/user_settings_live.ex` *(fails: exec: erl: not found)*
- `mix test` *(fails: exec: erl: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895aa3336308330a50431322731a234