### PR TITLE
Apply layout and Tailwind to user pages

### DIFF
--- a/lib/ain_com_booking_web/components/layouts/app.html.heex
+++ b/lib/ain_com_booking_web/components/layouts/app.html.heex
@@ -1,4 +1,6 @@
 <main role="main">
+  <AinComBookingWeb.Home.HTML.header />
+
   <div class="flash-messages">
     <.flash flash={@flash} kind={:success} />
     <.flash flash={@flash} kind={:error} />

--- a/lib/ain_com_booking_web/components/layouts/root.html.heex
+++ b/lib/ain_com_booking_web/components/layouts/root.html.heex
@@ -2,14 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href={Routes.static_url(@conn, "/assets/app.css")} />
-    <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
-    <script type="text/javascript" src={Routes.static_url(@conn, "/assets/app.js")}></script>
+    <.csrf_meta_tag />
+    <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
+    <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>
 
-  <body>
+  <body class="antialiased">
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- include home header component in application layout so auth pages share the same look
- load Tailwind assets in root layout via `phx-track-static` links

## Testing
- `mix format lib/ain_com_booking_web/components/layouts/app.html.heex lib/ain_com_booking_web/components/layouts/root.html.heex` *(fails: erl not found)*
- `mix test` *(fails: `init terminating in do_boot`)*


------
https://chatgpt.com/codex/tasks/task_e_6895b676acb4833080a587ca81e70259