### PR TITLE
Fix CSRF meta tag in root layout

### DIFF
--- a/lib/ain_com_booking_web/components/layouts.ex
+++ b/lib/ain_com_booking_web/components/layouts.ex
@@ -1,9 +1,7 @@
 defmodule AinComBookingWeb.Layouts do
   @moduledoc false
-  # use AinComBookingWeb, :html
-  use Phoenix.Component
+  use AinComBookingWeb, :html
 
-  alias AinComBookingWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
 
   embed_templates("layouts/*")

--- a/lib/ain_com_booking_web/components/layouts/root.html.heex
+++ b/lib/ain_com_booking_web/components/layouts/root.html.heex
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <.csrf_meta_tag />
+    <%= csrf_meta_tag() %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>


### PR DESCRIPTION
## Summary
- use Phoenix HTML helpers in `AinComBookingWeb.Layouts`
- render CSRF meta tag using `csrf_meta_tag()` in root layout

## Testing
- `mix format lib/ain_com_booking_web/components/layouts/root.html.heex lib/ain_com_booking_web/components/layouts.ex` *(fails: dependencies missing)*
- `mix deps.get` *(fails: Unknown package vega_lite in lockfile)*
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895d32a8a1c8330a6245cf765851e2a