### PR TITLE
Move Alpine state to controller assigns

### DIFF
--- a/lib/ain_com_booking_web/admin/controller.ex
+++ b/lib/ain_com_booking_web/admin/controller.ex
@@ -5,11 +5,16 @@ defmodule AinComBookingWeb.Admin.Controller do
 
   @spec index(Plug.Conn.t(), map) :: Plug.Conn.t()
   def index(conn, _) do
-    # <%= render "partials/header.html", assigns |> Map.merge(%{title: "Dashboard", user: @current_user}) %>
     conn
     |> assign(:variant, :main)
     |> assign(:body_class, "main")
-    |> Map.merge(%{title: "Dashboard", sidebarToggle: true})
+    |> assign(:title, "Dashboard")
+    |> assign(:sidebar_toggle, true)
+    |> assign(:menu_toggle, false)
+    |> assign(:dark_mode, false)
+    |> assign(:notification_dropdown_open, false)
+    |> assign(:notifying, true)
+    |> assign(:user_dropdown_open, false)
     |> render(:index, message: "Hello, world!")
   end
 end

--- a/lib/ain_com_booking_web/admin/templates/partials/partials_header.html.heex
+++ b/lib/ain_com_booking_web/admin/templates/partials/partials_header.html.heex
@@ -1,5 +1,5 @@
 <header
-  x-data="{menuToggle: false}"
+  x-data="{menuToggle: @menu_toggle, sidebarToggle: @sidebar_toggle, darkMode: @dark_mode}"
   class="sticky top-0 z-99999 flex w-full border-gray-200 bg-white lg:border-b dark:border-gray-800 dark:bg-gray-900"
 >
   <div
@@ -195,7 +195,7 @@
         <!-- Notification Menu Area -->
         <div
           class="relative"
-          x-data="{ dropdownOpen: false, notifying: true }"
+          x-data="{ dropdownOpen: @notification_dropdown_open, notifying: @notifying }"
           @click.outside="dropdownOpen = false"
         >
           <button
@@ -584,7 +584,7 @@
       <!-- User Area -->
       <div
         class="relative"
-        x-data="{ dropdownOpen: false }"
+        x-data="{ dropdownOpen: @user_dropdown_open }"
         @click.outside="dropdownOpen = false"
       >
         <a


### PR DESCRIPTION
## Summary
- Initialize menu, sidebar, dark mode, and dropdown state in Admin controller assigns
- Use assigns for Alpine.js state in admin header partial

## Testing
- `mix test` *(fails: init terminating in do_boot (undef))*

------
https://chatgpt.com/codex/tasks/task_e_689d6250a6c88330a3ce85c64c48a620