### PR TITLE
Resolve header conflict in dashboard layout

### DIFF
--- a/lib/ain_com_booking_web/components/layouts.ex
+++ b/lib/ain_com_booking_web/components/layouts.ex
@@ -3,7 +3,7 @@ defmodule AinComBookingWeb.Layouts do
   use AinComBookingWeb, :html
 
   alias Phoenix.LiveView.JS
-  import AinComBookingWeb.AdminComponents
+  alias AinComBookingWeb.AdminComponents
 
   # knobs the layout responds to
   attr(:variant, :atom, values: [:app, :auth, :settings, :main, :dashboard], default: :app)

--- a/lib/ain_com_booking_web/components/layouts/root.html.heex
+++ b/lib/ain_com_booking_web/components/layouts/root.html.heex
@@ -62,9 +62,9 @@
 
     <% :dashboard -> %>
       <div class="flex">
-        <.sidebar />
+        <AdminComponents.sidebar />
         <div class="flex-1">
-          <.header />
+          <AdminComponents.header />
           <main class="p-6">
             <%= @inner_content %>
           </main>


### PR DESCRIPTION
## Summary
- fix ambiguous header component by namespacing AdminComponents in layout
- update dashboard template to reference AdminComponents explicitly

## Testing
- `mix format` *(fails: dependencies missing: bcrypt_elixir, mix_audit, phoenix_live_view, ...)*
- `mix test` *(fails: dependencies missing: bcrypt_elixir, mix_audit, phoenix_live_view, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a48614c8688330b3dcd00577495122